### PR TITLE
Optimize docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ ARG VERSION=1.0-SNAPSHOT
 
 RUN yum update -y && \
     yum install -y \
-       java-1.8.0-openjdk \
-       java-1.8.0-openjdk-devel
+       java-1.8.0-openjdk-headless && \
+    yum clean all
 
 ENV JAVA_HOME /etc/alternatives/jre
 


### PR DESCRIPTION
I was able to shave off about 100MB from the final image size by installing openjdk-headless, removing the -devel package and cleaning yum metadata

che-starter still seems to run fine after these changes