### PR TITLE
Fixed returned list of stacks - now only 30 stacks were returned

### DIFF
--- a/src/main/java/io/fabric8/che/starter/client/CheRestEndpoints.java
+++ b/src/main/java/io/fabric8/che/starter/client/CheRestEndpoints.java
@@ -20,7 +20,7 @@ public enum CheRestEndpoints {
     GET_WORKSPACE_BY_ID ("/api/workspace/{id}"),
     LIST_WORKSPACES     ("/api/workspace"),
     STOP_WORKSPACE      ("/api/workspace/{id}/runtime"),
-    LIST_STACKS         ("/api/stack"),
+    LIST_STACKS         ("/api/stack?maxItems=1000"),
     CREATE_PROJECT      ("/project/batch");
 
     private final String endpoint;


### PR DESCRIPTION
Vert.x stack was not returned among the response. Stack limit set to 1000, it is far more than we can anticipate to have there.