### PR TITLE
Increased workspace starting timeout

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -16,6 +16,6 @@ server.port = 10000
 che.openshift.deploymentconfig=che
 che.openshift.route=che
 che-host.openshift.route=che-host
-che.workspace.start.timeout=60000
+che.workspace.start.timeout=180000
 che.openshift.start.timeout=90
 che.server.template.url = http://central.maven.org/maven2/io/fabric8/online/apps/che/1.0.30/che-1.0.30-openshift.json


### PR DESCRIPTION
fixes #83 
Timeout set to 3 minutes. It usually takes ~2 minutes to start locally on minishift. 