### PR TITLE
Split out configMap to make prod deployment easier

### DIFF
--- a/openshift-template/che-starter.app.yaml
+++ b/openshift-template/che-starter.app.yaml
@@ -42,13 +42,22 @@ objects:
         containers:
           - env:
             - name: OSO_ADDRESS
-              value: tsrv.devshift.net:8443
+              valueFrom:
+              configMapKeyRef:
+                name: che-starter
+                key: oso.address
             - name: OSO_DOMAIN_NAME
-              value: tsrv.devshift.net
+              valueFrom:
+              configMapKeyRef:
+                name: che-starter
+                key: oso.domain.name
             - name: KUBERNETES_CERTS_CA_FILE
-              value: '/opt/che-starter/tsrv.devshift.net.cer'
+              valueFrom:
+              configMapKeyRef:
+                name: che-starter
+                key: kubes.certs.ca.file
             name: che-starter
-            image: 'rhche/che-starter:latest'
+            image: ${IMAGE}:${IMAGE_TAG}
             ports:
               - containerPort: 10000
                 protocol: TCP
@@ -95,3 +104,8 @@ objects:
       name: che-starter
       weight: 100
     wildcardPolicy: None
+parameters:
+- name: IMAGE
+  value: rhche/che-starter
+- name: IMAGE_TAG
+  value: latest

--- a/openshift-template/che-starter.config.yaml
+++ b/openshift-template/che-starter.config.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: che-starter
+  creationTimestamp: null
+objects:
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: che-starter
+  type: Opaque
+  data:
+    oso.domain.name: tsrv.devshift.net
+    oso.address: tsrv.devshift.net:8443
+    kubes.certs.ca.file: /opt/che-starter/tsrv.devshift.net.cer

--- a/openshift-template/che-starter.config.yaml
+++ b/openshift-template/che-starter.config.yaml
@@ -1,15 +1,9 @@
 apiVersion: v1
-kind: Template
+kind: ConfigMap
 metadata:
   name: che-starter
-  creationTimestamp: null
-objects:
-- apiVersion: v1
-  kind: ConfigMap
-  metadata:
-    name: che-starter
-  type: Opaque
-  data:
-    oso.domain.name: tsrv.devshift.net
-    oso.address: tsrv.devshift.net:8443
-    kubes.certs.ca.file: /opt/che-starter/tsrv.devshift.net.cer
+type: Opaque
+data:
+  oso.domain.name: tsrv.devshift.net
+  oso.address: tsrv.devshift.net:8443
+  kubes.certs.ca.file: /opt/che-starter/tsrv.devshift.net.cer


### PR DESCRIPTION
new PR based on discussion in https://github.com/redhat-developer/che-starter/pull/96

