### PR TITLE
Fixed workspace startup of previously running workspace

### DIFF
--- a/src/main/java/io/fabric8/che/starter/client/ProjectClient.java
+++ b/src/main/java/io/fabric8/che/starter/client/ProjectClient.java
@@ -105,7 +105,7 @@ public class ProjectClient {
 
     @Async
     public void deleteAllProjectsAndWorkspace(String cheServerURL, String workspaceName) throws WorkspaceNotFound {
-        Workspace differentWorkspace = workspaceClient.getStartedWorkspace(cheServerURL);
+        Workspace runningWorkspace = workspaceClient.getStartedWorkspace(cheServerURL);
 
         Workspace workspaceToDelete = workspaceClient.startWorkspace(cheServerURL, workspaceName);
         workspaceClient.waitUntilWorkspaceIsRunning(cheServerURL, workspaceToDelete);
@@ -122,8 +122,8 @@ public class ProjectClient {
         workspaceClient.waitUntilWorkspaceIsStopped(cheServerURL, workspaceToDelete);
         workspaceClient.deleteWorkspace(cheServerURL, workspaceToDelete.getId());
 
-        if (differentWorkspace != null) {
-            workspaceClient.startWorkspace(cheServerURL, differentWorkspace.getConfig().getName());
+        if (runningWorkspace != null && !runningWorkspace.getConfig().getName().equals(workspaceName)) {
+            workspaceClient.startWorkspace(cheServerURL, runningWorkspace.getConfig().getName());
         }
     }
     


### PR DESCRIPTION
If there was only 1 workspace running and potentially someone would call DELETE /workspace/{name} endpoint, it would work, but in the end NPE would be thrown upon attempt to start up previously running WS. This PR should fix this by comparing name of a workspace to delete to name of a running workspace at the beginning of deletion.