### PR TITLE
Che #145: Setting 3 mins as server connection timeout

### DIFF
--- a/src/main/java/io/fabric8/che/starter/openshift/CheDeploymentConfig.java
+++ b/src/main/java/io/fabric8/che/starter/openshift/CheDeploymentConfig.java
@@ -84,7 +84,7 @@ public final class CheDeploymentConfig {
             public void run() {
                 poller.cancel(true);
             }
-        }, Integer.valueOf(startTimeout), TimeUnit.SECONDS);
+        }, Integer.valueOf(startTimeout), TimeUnit.MILLISECONDS);
         try {
             while (!waitUntilReady(queue)) {
             }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,10 +13,11 @@
 include.error.stack.trace = true
 logging.level. = INFO
 server.port = 10000
+server.connection-timeout= 180000
 che.openshift.deploymentconfig=che
 che.openshift.route=che
 che-host.openshift.route=che-host
 che.workspace.start.timeout=300000
 che.workspace.stop.timeout=150000
-che.openshift.start.timeout=90
+che.openshift.start.timeout=180000
 che.server.template.url = http://central.maven.org/maven2/io/fabric8/online/apps/che/1.0.30/che-1.0.30-openshift.json


### PR DESCRIPTION
tested locally against free int cluster - solutions seems to work 
`server.connection-timeout= # Time in milliseconds that connectors will wait for another HTTP request before closing the connection. When not set, the connector's container-specific default will be used. Use a value of -1 to indicate no (i.e. infinite) timeout.`

More details in https://docs.spring.io/spring-boot/docs/current/reference/html/common-application-properties.html