### PR TITLE
che #163 - Adding PATCH '/server' endpoint for starting idled che-server

### DIFF
--- a/src/main/java/io/fabric8/che/starter/client/CheServerClient.java
+++ b/src/main/java/io/fabric8/che/starter/client/CheServerClient.java
@@ -13,10 +13,12 @@
 package io.fabric8.che.starter.client;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
-import io.fabric8.che.starter.model.response.CheServerInfo;
+import io.fabric8.che.starter.model.server.CheServerInfo;
 import io.fabric8.che.starter.openshift.CheDeploymentConfig;
+import io.fabric8.che.starter.util.CheServerHelper;
 import io.fabric8.openshift.client.OpenShiftClient;
 
 @Component
@@ -25,11 +27,15 @@ public class CheServerClient {
     @Autowired
     CheDeploymentConfig cheDeploymentConfig;
 
-    public CheServerInfo getCheServerInfo(OpenShiftClient client, String namespace) {
+    public CheServerInfo getCheServerInfo(OpenShiftClient client, String namespace, String requestURL) {
         boolean isRunning = cheDeploymentConfig.isDeploymentAvailable(client, namespace);
-        CheServerInfo info = new CheServerInfo();
-        info.setRunning(isRunning);
+        CheServerInfo info = CheServerHelper.generateCheServerInfo(isRunning, requestURL);
         return info;
+    }
+
+    @Async
+    public void startCheServer(OpenShiftClient client, String namespace) {
+        cheDeploymentConfig.deployCheIfSuspended(client, namespace);
     }
 
 }

--- a/src/main/java/io/fabric8/che/starter/model/server/CheServerInfo.java
+++ b/src/main/java/io/fabric8/che/starter/model/server/CheServerInfo.java
@@ -10,13 +10,16 @@
  * http://www.eclipse.org/legal/epl-v10.html
  * #L%
  */
-package io.fabric8.che.starter.model.response;
+package io.fabric8.che.starter.model.server;
+
+import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class CheServerInfo {
     private boolean isRunning;
+    private List<CheServerLink> links;
 
     public boolean isRunning() {
         return isRunning;
@@ -24,6 +27,14 @@ public class CheServerInfo {
 
     public void setRunning(boolean isRunning) {
         this.isRunning = isRunning;
+    }
+
+    public List<CheServerLink> getLinks() {
+        return links;
+    }
+
+    public void setLinks(List<CheServerLink> links) {
+        this.links = links;
     }
 
 }

--- a/src/main/java/io/fabric8/che/starter/model/server/CheServerLink.java
+++ b/src/main/java/io/fabric8/che/starter/model/server/CheServerLink.java
@@ -1,0 +1,47 @@
+/*-
+ * #%L
+ * che-starter
+ * %%
+ * Copyright (C) 2017 Red Hat, Inc.
+ * %%
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * #L%
+ */
+package io.fabric8.che.starter.model.server;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CheServerLink {
+    private String href;
+    private String rel;
+    private String method;
+
+    public String getHref() {
+        return href;
+    }
+
+    public void setHref(String href) {
+        this.href = href;
+    }
+
+    public String getRel() {
+        return rel;
+    }
+
+    public void setRel(String rel) {
+        this.rel = rel;
+    }
+
+    public String getMethod() {
+        return method;
+    }
+
+    public void setMethod(String method) {
+        this.method = method;
+    }
+
+}

--- a/src/main/java/io/fabric8/che/starter/util/CheServerHelper.java
+++ b/src/main/java/io/fabric8/che/starter/util/CheServerHelper.java
@@ -1,0 +1,43 @@
+/*-
+ * #%L
+ * che-starter
+ * %%
+ * Copyright (C) 2017 Red Hat, Inc.
+ * %%
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * #L%
+ */
+package io.fabric8.che.starter.util;
+
+import java.util.Collections;
+
+import io.fabric8.che.starter.model.server.CheServerInfo;
+import io.fabric8.che.starter.model.server.CheServerLink;
+
+public final class CheServerHelper {
+    public static final String CHE_SERVER_STATUS_URL = "server status url";
+    private static final String HTTP_METHOD_GET = "GET";
+
+    private CheServerHelper() {
+    }
+
+    public static CheServerInfo generateCheServerInfo(boolean isRunning, String requestURL) {
+        CheServerInfo info = new CheServerInfo();
+        info.setRunning(isRunning);
+        CheServerLink statusLink = CheServerHelper.generateStatusLink(requestURL);
+        info.setLinks(Collections.singletonList(statusLink));
+        return info;
+    }
+
+    private static CheServerLink generateStatusLink(final String href) {
+        CheServerLink statusLink = new CheServerLink();
+        statusLink.setHref(href);
+        statusLink.setMethod(HTTP_METHOD_GET);
+        statusLink.setRel(CHE_SERVER_STATUS_URL);
+        return statusLink;
+    }
+
+}

--- a/src/test/java/io/fabric8/che/starter/client/keycloak/KeycloakTokenValidatorTest.java
+++ b/src/test/java/io/fabric8/che/starter/client/keycloak/KeycloakTokenValidatorTest.java
@@ -1,0 +1,34 @@
+/*-
+ * #%L
+ * che-starter
+ * %%
+ * Copyright (C) 2017 Red Hat, Inc.
+ * %%
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * #L%
+ */
+package io.fabric8.che.starter.client.keycloak;
+
+import org.junit.Test;
+
+import io.fabric8.che.starter.TestConfig;
+import io.fabric8.che.starter.exception.KeycloakException;
+
+public class KeycloakTokenValidatorTest extends TestConfig {
+    private static final String VALID_TOKEN = "Bearer token";
+    private static final String INVALID_TOKEN = "token";
+
+
+    @Test
+    public void processValidToken() throws KeycloakException {
+        KeycloakTokenValidator.validate(VALID_TOKEN);
+    }
+
+    @Test(expected = KeycloakException.class)
+    public void processInvalidToken() throws KeycloakException {
+        KeycloakTokenValidator.validate(INVALID_TOKEN);
+    }
+}

--- a/src/test/java/io/fabric8/che/starter/util/CheServerHelperTest.java
+++ b/src/test/java/io/fabric8/che/starter/util/CheServerHelperTest.java
@@ -1,0 +1,44 @@
+/*-
+ * #%L
+ * che-starter
+ * %%
+ * Copyright (C) 2017 Red Hat, Inc.
+ * %%
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * #L%
+ */
+package io.fabric8.che.starter.util;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import io.fabric8.che.starter.TestConfig;
+import io.fabric8.che.starter.model.server.CheServerInfo;
+import io.fabric8.che.starter.model.server.CheServerLink;
+
+public class CheServerHelperTest extends TestConfig {
+    private static final boolean IS_RUNNING = true;
+    private static final String REQUEST_URL = "http://localhost:10000/server";
+
+    @Test
+    public void checkCheServerStatusLink() {
+        CheServerInfo info = CheServerHelper.generateCheServerInfo(IS_RUNNING, REQUEST_URL);
+        List<CheServerLink> links = info.getLinks();
+
+        assertTrue(info.isRunning());
+        assertFalse(links.isEmpty());
+
+        CheServerLink statusLink = links.stream()
+                .filter(link -> CheServerHelper.CHE_SERVER_STATUS_URL.equals(link.getRel())).findFirst().get();
+
+        assertEquals(REQUEST_URL, statusLink.getHref());
+    }
+}


### PR DESCRIPTION
Example of `server/` `GET` & `PATCH` response:
```
{
  "links": [
    {
      "href": "http://localhost:10000/server",
      "rel": "server status url",
      "method": "GET"
    }
  ],
  "running": true
}
```
`PATCH` returns `200` is che-server is running & `202` if starting of the server has been scheduled
`server status url` should be called for obtaining che server status (if it's running or not) 
