### PR TITLE
rh-che 92: Adding atributes to workspace commands. Updating wildfly & node.js stack id

### DIFF
--- a/src/main/java/io/fabric8/che/starter/model/stack/StackProjectMapping.java
+++ b/src/main/java/io/fabric8/che/starter/model/stack/StackProjectMapping.java
@@ -28,8 +28,8 @@ public final class StackProjectMapping {
             put("java-centos", "maven").
             put("vert.x", "maven").
             put("spring-boot", "maven").
-            put("WildFly Swarm", "maven").
-            put("CentOS nodejs", "node-js").
+            put("wildfly-swarm", "maven").
+            put("nodejs4", "node-js").
             build();
 
     private StackProjectMapping() {

--- a/src/main/java/io/fabric8/che/starter/model/workspace/WorkspaceCommand.java
+++ b/src/main/java/io/fabric8/che/starter/model/workspace/WorkspaceCommand.java
@@ -16,10 +16,10 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class WorkspaceCommand {
-
     private String commandLine;
     private String name;
     private String type;
+    private WorkspaceCommandAttributes attributes;
 
     public String getCommandLine() {
         return commandLine;
@@ -43,6 +43,14 @@ public class WorkspaceCommand {
 
     public void setType(String type) {
         this.type = type;
+    }
+
+    public WorkspaceCommandAttributes getAttributes() {
+        return attributes;
+    }
+
+    public void setAttributes(WorkspaceCommandAttributes attributes) {
+        this.attributes = attributes;
     }
 
 }

--- a/src/main/java/io/fabric8/che/starter/model/workspace/WorkspaceCommandAttributes.java
+++ b/src/main/java/io/fabric8/che/starter/model/workspace/WorkspaceCommandAttributes.java
@@ -1,0 +1,40 @@
+/*-
+ * #%L
+ * che-starter
+ * %%
+ * Copyright (C) 2017 Red Hat, Inc.
+ * %%
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * #L%
+ */
+package io.fabric8.che.starter.model.workspace;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public class WorkspaceCommandAttributes {
+    private String previewUrl;
+    private String goal;
+
+    public String getPreviewUrl() {
+        return previewUrl;
+    }
+
+    public void setPreviewUrl(String previewUrl) {
+        this.previewUrl = previewUrl;
+    }
+
+    public String getGoal() {
+        return goal;
+    }
+
+    public void setGoal(String goal) {
+        this.goal = goal;
+    }
+
+}

--- a/src/test/java/io/fabric8/che/starter/client/StackClientTest.java
+++ b/src/test/java/io/fabric8/che/starter/client/StackClientTest.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 
+import org.junit.Ignore;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,6 +33,10 @@ import io.fabric8.che.starter.model.stack.StackProjectMapping;
 public class StackClientTest extends TestConfig {
     private static final Logger LOG = LoggerFactory.getLogger(StackClientTest.class);
     private static final String VERTX_STACK_ID = "vert.x";
+    private static final String JAVA_CENTOS_STACK_ID = "java-centos";
+    private static final String SPRING_BOOT_STACK_ID = "spring-boot";
+    private static final String WILDFLY_SWARM_STACK_ID = "wildfly-swarm";
+    private static final String NODE_JS_STACK_ID = "nodejs4";
     private static final String NON_EXISTING_STACK_ID = "non-existing-stack-id";
     private static final String KEYCLOAK_TOKEN = null;
 
@@ -59,8 +64,34 @@ public class StackClientTest extends TestConfig {
 
     @Test
     public void getVertxStack() throws StackNotFoundException {
-        Stack vertxStack = client.getStack(cheServerUrl, VERTX_STACK_ID, KEYCLOAK_TOKEN);
-        LOG.info("vertx stack is found: {}", vertxStack);
+        Stack vertx = client.getStack(cheServerUrl, VERTX_STACK_ID, KEYCLOAK_TOKEN);
+        LOG.info("'vert.x' stack is found: {}", vertx);
+    }
+
+    @Test
+    public void getJavaCentosStack() throws StackNotFoundException {
+        Stack javaCentos = client.getStack(cheServerUrl, JAVA_CENTOS_STACK_ID, KEYCLOAK_TOKEN);
+        LOG.info("'java-centos' stack is found: {}", javaCentos);
+    }
+
+    @Test
+    public void getSpringBootStack() throws StackNotFoundException {
+        Stack springBoot = client.getStack(cheServerUrl, SPRING_BOOT_STACK_ID, KEYCLOAK_TOKEN);
+        LOG.info("'spring-boot' stack is found: {}", springBoot);
+    }
+
+    @Test
+    @Ignore("Need to update che-server test environment on free int cluster")
+    public void getWildflySwarmStack() throws StackNotFoundException {
+        Stack wildflySwarm = client.getStack(cheServerUrl, WILDFLY_SWARM_STACK_ID, KEYCLOAK_TOKEN);
+        LOG.info("'wildfly-swarm' stack is found: {}", wildflySwarm);
+    }
+
+    @Test
+    @Ignore("Need to update che-server test environment on free int cluster")
+    public void getNodeJsStack() throws StackNotFoundException {
+        Stack nodeJs = client.getStack(cheServerUrl, NODE_JS_STACK_ID, KEYCLOAK_TOKEN);
+        LOG.info("'nodejs4' stack is found: {}", nodeJs);
     }
 
     @Test

--- a/src/test/java/io/fabric8/che/starter/client/WorkspaceClientTest.java
+++ b/src/test/java/io/fabric8/che/starter/client/WorkspaceClientTest.java
@@ -32,7 +32,7 @@ public class WorkspaceClientTest extends TestConfig {
     private static final Logger LOG = LoggerFactory.getLogger(WorkspaceClientTest.class);
     private static final String GITHUB_REPO = "https://github.com/che-samples/console-java-simple";
     private static final String BRANCH = "master";
-    private static final String STACK_ID = "java-default";
+    private static final String STACK_ID = "java-centos";
     private static final String DESCRIPTION = GITHUB_REPO + "#" + BRANCH + "#" + "WI1345";
     private static final String KEYCLOAK_TOKEN = null;
     private static final String MASTER_URL = "";


### PR DESCRIPTION
After applying this PR commands for vert.x stack looks the following way:  
```
      {
          "commandLine": "scl enable rh-maven33 'mvn clean install -f ${current.project.path}'",
          "name": "build",
          "type": "mvn",
          "attributes": {
            "goal": "Build"
          }
        },
        {
          "commandLine": "cd ${current.project.path} && scl enable rh-maven33 'java -jar target/*-fat.jar'",
          "name": "run",
          "type": "custom",
          "attributes": {
            "previewUrl": "http://${server.port.8080}",
            "goal": "Run"
          }
        }
```

After creating workspace "Run" command looks the following way

![image](https://user-images.githubusercontent.com/1461122/28413958-cb876b10-6d49-11e7-9037-fdeeda51a57e.png)



