### PR TITLE
che-starter #202: GitHub primary email should be used in committer info if there is no public email available

### DIFF
--- a/src/main/java/io/fabric8/che/starter/client/WorkspacePreferencesClient.java
+++ b/src/main/java/io/fabric8/che/starter/client/WorkspacePreferencesClient.java
@@ -23,9 +23,10 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 
+import io.fabric8.che.starter.client.github.GitHubClient;
 import io.fabric8.che.starter.client.keycloak.KeycloakRestTemplate;
-import io.fabric8.che.starter.model.GitHubUserInfo;
 import io.fabric8.che.starter.model.WorkspacePreferences;
+import io.fabric8.che.starter.model.github.GitHubUserInfo;
 
 @Component
 public class WorkspacePreferencesClient {

--- a/src/main/java/io/fabric8/che/starter/client/github/GitHubClient.java
+++ b/src/main/java/io/fabric8/che/starter/client/github/GitHubClient.java
@@ -10,13 +10,16 @@
  * http://www.eclipse.org/legal/epl-v10.html
  * #L%
  */
-package io.fabric8.che.starter.client;
+package io.fabric8.che.starter.client.github;
 
 import java.io.IOException;
+import java.util.List;
 
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -25,18 +28,22 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 
+import io.fabric8.che.starter.client.CheRestEndpoints;
 import io.fabric8.che.starter.client.keycloak.KeycloakRestTemplate;
 import io.fabric8.che.starter.exception.GitHubOAthTokenException;
-import io.fabric8.che.starter.model.GitHubUserInfo;
 import io.fabric8.che.starter.model.Token;
+import io.fabric8.che.starter.model.github.GitHubEmail;
+import io.fabric8.che.starter.model.github.GitHubUserInfo;
 
 @Component
 public class GitHubClient {
     private static final Logger LOG = LoggerFactory.getLogger(GitHubClient.class);
 
     @Value("${GITHUB_USER_URL:https://api.github.com/user}")
-    private String GIT_HUB_USER_ENDPOINT;
+    private String GITHUB_USER_URL;
 
+    @Value("${GITHUB_EMAIL_URL:https://api.github.com/user/emails}")
+    private String GITHUB_EMAIL_URL;
     /**
      * Uploads the Github oAuth token to the workspace so that the developer can send push requests
      *  
@@ -60,7 +67,7 @@ public class GitHubClient {
         try {
             template.postForLocation(url, entity);
         } catch (Exception e) {
-            LOG.warn("Error setting GitHub OAuth token on Che Server: {}, trying new version of API", cheServerURL);
+            LOG.info("Trying new version of API - Unable to set GitHub OAuth token via '{}'", url);
             try {
                 setGitHubOAuthTokenVersion2(cheServerURL, template, entity);
             } catch (Exception ex) {
@@ -69,19 +76,36 @@ public class GitHubClient {
         }
     }
 
+    /**
+     * Get {@link GitHubUserInfo} using GitHub public API. If there is no public
+     * email specified - fetch "primary" email using `/user/email` endpoint
+     * 
+     * @param gitHubToken
+     * @return GitHub committer info - 'name' and 'email'
+     */
     public GitHubUserInfo getUserInfo(final String gitHubToken) {
-        RestTemplate template = new RestTemplate();
-        HttpHeaders headers = new HttpHeaders();
-        headers.add("Authorization", "Bearer " + gitHubToken);
-        HttpEntity<String> entity = new HttpEntity<String>("parameters", headers);
-        headers.setContentType(MediaType.APPLICATION_JSON);
-        ResponseEntity<GitHubUserInfo> response = template.exchange(GIT_HUB_USER_ENDPOINT, HttpMethod.GET, entity, GitHubUserInfo.class);
-        return response.getBody();
+        RestTemplate template = new GitHubRestTemplate(gitHubToken);
+        GitHubUserInfo info = template.getForObject(GITHUB_USER_URL, GitHubUserInfo.class);
+        String publicEmail = info.getEmail();
+        if (StringUtils.isBlank(publicEmail)) {
+            GitHubEmail primaryEmail = getPrimaryEmail(gitHubToken);
+            info.setEmail(primaryEmail.getEmail());
+        }
+        return info;
+    }
+
+    public GitHubEmail getPrimaryEmail(final String gitHubToken) {
+        RestTemplate template = new GitHubRestTemplate(gitHubToken);
+        ResponseEntity<List<GitHubEmail>> response = template.exchange(GITHUB_EMAIL_URL, HttpMethod.GET, null, new ParameterizedTypeReference<List<GitHubEmail>>(){});
+        List<GitHubEmail> emails = response.getBody();
+        GitHubEmail primary = emails.stream().filter(e -> e.isPrimary()).findFirst().get();
+        return primary;
     }
 
     private void setGitHubOAuthTokenVersion2(String cheServerURL, RestTemplate template, HttpEntity<Token> entity) {
         String url = cheServerURL + CheRestEndpoints.SET_OAUTH_TOKEN_V2.getEndpoint();
         template.postForLocation(url, entity);
+        LOG.info("GitHub OAuth token has been successfully set via '{}'", url);
     }
 
 }

--- a/src/main/java/io/fabric8/che/starter/client/github/GitHubInterceptor.java
+++ b/src/main/java/io/fabric8/che/starter/client/github/GitHubInterceptor.java
@@ -1,0 +1,43 @@
+/*-
+ * #%L
+ * che-starter
+ * %%
+ * Copyright (C) 2017 Red Hat, Inc.
+ * %%
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * #L%
+ */
+package io.fabric8.che.starter.client.github;
+
+import java.io.IOException;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.http.client.ClientHttpResponse;
+
+class GitHubInterceptor implements ClientHttpRequestInterceptor {
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String USER_AGENT_HEADER = "User-Agent";
+    private static final String USER_AGENT_VALUE = "openshift.io";
+    private String gitHubToken;
+
+    public GitHubInterceptor(String gitHubToken) {
+        this.gitHubToken = "Bearer " + gitHubToken;
+    }
+
+    @Override
+    public ClientHttpResponse intercept(HttpRequest request, byte[] body, ClientHttpRequestExecution execution)
+            throws IOException {
+        HttpHeaders headers = request.getHeaders();
+        headers.add(AUTHORIZATION_HEADER, gitHubToken);
+        headers.add(USER_AGENT_HEADER, USER_AGENT_VALUE);
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        return execution.execute(request, body);
+    }
+}

--- a/src/main/java/io/fabric8/che/starter/client/github/GitHubRestTemplate.java
+++ b/src/main/java/io/fabric8/che/starter/client/github/GitHubRestTemplate.java
@@ -1,0 +1,28 @@
+/*-
+ * #%L
+ * che-starter
+ * %%
+ * Copyright (C) 2017 Red Hat, Inc.
+ * %%
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * #L%
+ */
+package io.fabric8.che.starter.client.github;
+
+import java.util.Collections;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.web.client.RestTemplate;
+
+public class GitHubRestTemplate extends RestTemplate {
+
+    public GitHubRestTemplate(final String gitHubToken) {
+        if (StringUtils.isNotBlank(gitHubToken)) {
+            this.setInterceptors(Collections.singletonList(new GitHubInterceptor(gitHubToken)));
+        }
+    }
+
+}

--- a/src/main/java/io/fabric8/che/starter/controller/WorkspaceController.java
+++ b/src/main/java/io/fabric8/che/starter/controller/WorkspaceController.java
@@ -32,15 +32,14 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestClientException;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 
-import io.fabric8.che.starter.client.GitHubClient;
 import io.fabric8.che.starter.client.ProjectClient;
 import io.fabric8.che.starter.client.WorkspaceClient;
 import io.fabric8.che.starter.client.WorkspacePreferencesClient;
+import io.fabric8.che.starter.client.github.GitHubClient;
 import io.fabric8.che.starter.client.keycloak.KeycloakClient;
 import io.fabric8.che.starter.client.keycloak.KeycloakTokenValidator;
 import io.fabric8.che.starter.exception.GitHubOAthTokenException;
@@ -268,7 +267,7 @@ public class WorkspaceController {
             tokenClient.setGitHubOAuthToken(cheServerURL, githubToken, keycloakToken);
             try {
                 workspacePreferencesClient.setCommitterInfo(cheServerURL, githubToken, keycloakToken);
-            } catch (HttpServerErrorException e) {
+            } catch (Exception e) {
                 LOG.warn("Unable to set committer info in Che Git preferences");
             }
         }

--- a/src/main/java/io/fabric8/che/starter/model/github/GitHubEmail.java
+++ b/src/main/java/io/fabric8/che/starter/model/github/GitHubEmail.java
@@ -1,0 +1,58 @@
+/*-
+ * #%L
+ * che-starter
+ * %%
+ * Copyright (C) 2017 Red Hat, Inc.
+ * %%
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * #L%
+ */
+package io.fabric8.che.starter.model.github;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public class GitHubEmail {
+    private String email;
+    private String visibility;
+    private boolean primary;
+    private boolean verified;
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getVisibility() {
+        return visibility;
+    }
+
+    public void setVisibility(String visibility) {
+        this.visibility = visibility;
+    }
+
+    public boolean isPrimary() {
+        return primary;
+    }
+
+    public void setPrimary(boolean primary) {
+        this.primary = primary;
+    }
+
+    public boolean isVerified() {
+        return verified;
+    }
+
+    public void setVerified(boolean verified) {
+        this.verified = verified;
+    }
+
+}

--- a/src/main/java/io/fabric8/che/starter/model/github/GitHubUserInfo.java
+++ b/src/main/java/io/fabric8/che/starter/model/github/GitHubUserInfo.java
@@ -10,7 +10,7 @@
  * http://www.eclipse.org/legal/epl-v10.html
  * #L%
  */
-package io.fabric8.che.starter.model;
+package io.fabric8.che.starter.model.github;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 

--- a/src/test/java/io/fabric8/che/starter/client/WorkspacePreferencesClientTest.java
+++ b/src/test/java/io/fabric8/che/starter/client/WorkspacePreferencesClientTest.java
@@ -15,6 +15,9 @@ package io.fabric8.che.starter.client;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
+import javax.annotation.PostConstruct;
+
+import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -24,14 +27,20 @@ import io.fabric8.che.starter.model.WorkspacePreferences;
 
 public class WorkspacePreferencesClientTest extends TestConfig {
     private static final String KEYCLOAK_TOKEN = null;
-    private static final String COMMITTER_NAME = "Ilya Buziuk";
-    private static final String COMMITTER_EMAIL = "ilyabuziuk@gmail.com";
+    private String committerName;
+    private String committerEmail;
 
     @Value("${che.server.url}")
     String cheServerUrl;
 
     @Autowired
     WorkspacePreferencesClient client;
+
+    @PostConstruct
+    public void init() {
+        this.committerName = generateCommitterName();
+        this.committerEmail = generateCommitterEmail();
+    }
 
     @Test
     public void setCommitterInfo() throws Exception {
@@ -43,15 +52,23 @@ public class WorkspacePreferencesClientTest extends TestConfig {
         WorkspacePreferences committerInfo = client.getCommitterInfo(cheServerUrl, KEYCLOAK_TOKEN);
 
         assertNotNull(committerInfo);
-        assertEquals(committerInfo.getCommiterName(), COMMITTER_NAME);
-        assertEquals(committerInfo.getCommiterEmail(), COMMITTER_EMAIL);
+        assertEquals(committerInfo.getCommiterName(), committerName);
+        assertEquals(committerInfo.getCommiterEmail(), committerEmail);
     }
 
     private WorkspacePreferences getTestPreferences() {
         WorkspacePreferences preferences = new WorkspacePreferences();
-        preferences.setCommitterName(COMMITTER_NAME);
-        preferences.setCommitterEmail(COMMITTER_EMAIL);
+        preferences.setCommitterName(committerName);
+        preferences.setCommitterEmail(committerEmail);
         return preferences;
+    }
+
+    private String generateCommitterEmail() {
+        return RandomStringUtils.random(10, true, true) + "@redhat.com";
+    }
+
+    private String generateCommitterName() {
+        return "John " + RandomStringUtils.random(10, true, true);
     }
 
 }

--- a/src/test/java/io/fabric8/che/starter/client/github/GitHubTokenClientTest.java
+++ b/src/test/java/io/fabric8/che/starter/client/github/GitHubTokenClientTest.java
@@ -10,7 +10,7 @@
  * http://www.eclipse.org/legal/epl-v10.html
  * #L%
  */
-package io.fabric8.che.starter.client;
+package io.fabric8.che.starter.client.github;
 
 import java.io.IOException;
 
@@ -22,12 +22,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 
 import io.fabric8.che.starter.TestConfig;
+import io.fabric8.che.starter.client.github.GitHubClient;
 import io.fabric8.che.starter.exception.GitHubOAthTokenException;
-import io.fabric8.che.starter.model.GitHubUserInfo;
+import io.fabric8.che.starter.model.github.GitHubEmail;
+import io.fabric8.che.starter.model.github.GitHubUserInfo;
 
 public class GitHubTokenClientTest extends TestConfig {
     private static final Logger LOG = LoggerFactory.getLogger(GitHubTokenClientTest.class);
-    private static final String GIT_HUB_TOKEN = "GIT_HUB_TOKEN";
+    private static final String GIT_HUB_TOKEN = "dummy_token";
     private static final String KEYCLOAK_TOKEN = null;
 
     @Value("${che.server.url}")
@@ -45,8 +47,16 @@ public class GitHubTokenClientTest extends TestConfig {
     @Test
     public void getUserInfo() {
         GitHubUserInfo userInfo = client.getUserInfo(GIT_HUB_TOKEN);
-        LOG.info(userInfo.getName());
-        LOG.info(userInfo.getEmail());
+        LOG.info("Committer Name {}", userInfo.getName());
+        LOG.info("Committer Email {}", userInfo.getEmail());
+    }
+
+    @Ignore("Valid GitHub token must be provided")
+    @Test
+    public void getPrimaryEmail() {
+        GitHubEmail primaryEmail = client.getPrimaryEmail(GIT_HUB_TOKEN);
+        String email = primaryEmail.getEmail();
+        LOG.info("Primary email {}", email);
     }
 
 }


### PR DESCRIPTION
- use "primary" email if there is no public one
- improve `setCommitterInfo` tests (name & email are generated for every test execution)
- improve log messages
- refactoring