### PR TITLE
Remove bash command from route yaml

### DIFF
--- a/openshift-template/che-starter.app.yaml
+++ b/openshift-template/che-starter.app.yaml
@@ -132,7 +132,6 @@ objects:
     name: che-starter
     creationTimestamp: null
   spec:
-    host: che-starter.$(minishift ip).nip.io
     to:
       kind: Service
       name: che-starter


### PR DESCRIPTION
Once https://github.com/almighty/almighty-jobs/pull/231 is merged, the bash command in route would start failing jobs (it prints error now, but we ignore it).

I don't think it is needed there anyway - without `host:` directive, OpenShift will generate url based on it's URL which should match what was there when evaluated, so there should be no change in behaviour.