### PR TITLE
che #6130: Workaround for workspace validator (currently allowed name is up to 20 chars)

### DIFF
--- a/src/main/java/io/fabric8/che/starter/util/WorkspaceHelper.java
+++ b/src/main/java/io/fabric8/che/starter/util/WorkspaceHelper.java
@@ -27,7 +27,7 @@ public class WorkspaceHelper {
     public static final String WORKSPACE_START_IDE_URL = "ide start url";
     public static final String WORKSPACE_IDE_URL = "ide url";
     public static final String HTTP_METHOD_PATCH = "PATCH";
-    public static final int RANDOM_POSTFIX_LENGTH = 8;
+    public static final int RANDOM_POSTFIX_LENGTH = 5;
 
     public List<Workspace> filterByRepository(final List<Workspace> workspaces, final String repository) {
         return workspaces.stream().filter(w -> {
@@ -89,9 +89,13 @@ public class WorkspaceHelper {
      * @param projectName
      * @return workspace name
      * @see https://github.com/openshiftio/openshift.io/issues/446
+     * @see https://github.com/eclipse/che/issues/6130 
      */
     public String generateName(final String projectName) {
-        return projectName + "-" + RandomStringUtils.random(RANDOM_POSTFIX_LENGTH, true, true).toLowerCase();
+        String randomPostfix = RandomStringUtils.random(RANDOM_POSTFIX_LENGTH, true, true).toLowerCase();
+        String workspaceName = projectName + "-" + randomPostfix;
+        // hot fix for workspace validator - currently max length for workspace name is 20 chars
+        return (workspaceName.length() <= 20) ? workspaceName : randomPostfix;
     }
 
     private String generateHrefForWorkspaceStartLink(final String requestURL, final String workspaceId) {

--- a/src/test/java/io/fabric8/che/starter/util/WorkspaceHelperTest.java
+++ b/src/test/java/io/fabric8/che/starter/util/WorkspaceHelperTest.java
@@ -27,7 +27,8 @@ import io.fabric8.che.starter.model.workspace.WorkspaceLink;
 
 public class WorkspaceHelperTest extends TestConfig {
     private static final String REQUEST_URL = "http://localhost:10000/workspace";
-    private static final String TEST_PROJECT_NAME = "test-project";
+    private static final String TEST_PROJECT_SHORT_NAME = "test-project";
+    private static final String TEST_PROJECT_LONG_NAME = "training-courses-management-system";
 
     @Autowired
     WorkspaceHelper workspaceHelper;
@@ -55,11 +56,13 @@ public class WorkspaceHelperTest extends TestConfig {
 
     @Test
     public void generateWorkspaceName() {
-        String workspaceName = workspaceHelper.generateName(TEST_PROJECT_NAME);
-        String[] split = workspaceName.split("-");
-        String randomPostfix = split[split.length - 1];
-        assertEquals(randomPostfix.length(), WorkspaceHelper.RANDOM_POSTFIX_LENGTH);
-        assertTrue(randomPostfix.matches("^[a-z0-9]+$"));
+        String workspaceNameForShortNamedProject = workspaceHelper.generateName(TEST_PROJECT_SHORT_NAME);
+        assertTrue(workspaceNameForShortNamedProject.startsWith(TEST_PROJECT_SHORT_NAME));
+        assertTrue(workspaceNameForShortNamedProject.matches("[a-zA-Z0-9][-_.a-zA-Z0-9]{1,18}[a-zA-Z0-9]"));
+
+        String workspaceNameForLongNamedProject = workspaceHelper.generateName(TEST_PROJECT_LONG_NAME);
+        assertEquals(workspaceNameForLongNamedProject.length(), WorkspaceHelper.RANDOM_POSTFIX_LENGTH);
+        assertTrue(workspaceNameForLongNamedProject.matches("[a-zA-Z0-9][-_.a-zA-Z0-9]{1,18}[a-zA-Z0-9]"));
     }
 
 }


### PR DESCRIPTION

Signed-off-by: Ilya Buziuk <ibuziuk@redhat.com>