### PR TITLE
Che starter needs to update tenant if user provisioned with multi-tenant che-server, but still has single-tenant che deployment in namespace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ local.properties
 # Eclipse Core
 .project
 
+# Checkstyle
+.checkstyle
+
 # External tool builders
 .externalToolBuilders/
 
@@ -58,7 +61,7 @@ local.properties
 ### Intellij ###
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
-
+.idea/
 # User-specific stuff:
 .idea/workspace.xml
 .idea/tasks.xml

--- a/pom.xml
+++ b/pom.xml
@@ -170,6 +170,7 @@
                     <excludes>
                         <exclude>test-output/**</exclude>
                         <exclude>target/**</exclude>
+                        <exclude>.idea/**</exclude>
                         <exclude>**/*.json</exclude>
                         <exclude>src/main/resources/checkstyle.xml</exclude>
                     </excludes>

--- a/src/main/java/io/fabric8/che/starter/client/CheServerClient.java
+++ b/src/main/java/io/fabric8/che/starter/client/CheServerClient.java
@@ -12,6 +12,8 @@
  */
 package io.fabric8.che.starter.client;
 
+import java.util.concurrent.TimeUnit;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
@@ -19,6 +21,7 @@ import org.springframework.stereotype.Component;
 import io.fabric8.che.starter.exception.RouteNotFoundException;
 import io.fabric8.che.starter.model.server.CheServerInfo;
 import io.fabric8.che.starter.multi.tenant.MultiTenantToggle;
+import io.fabric8.che.starter.multi.tenant.TenantUpdater;
 import io.fabric8.che.starter.openshift.CheDeploymentConfig;
 import io.fabric8.che.starter.openshift.CheServerRouteChecker;
 import io.fabric8.che.starter.util.CheServerHelper;
@@ -28,18 +31,34 @@ import io.fabric8.openshift.client.OpenShiftClient;
 public class CheServerClient {
 
     @Autowired
-    CheDeploymentConfig cheDeploymentConfig;
+    private CheDeploymentConfig cheDeploymentConfig;
     
     @Autowired
-    MultiTenantToggle toggle;
+    private MultiTenantToggle toggle;
 
     @Autowired
     private CheServerRouteChecker cheServerRouteChecker;
 
+    @Autowired
+    private TenantUpdater tenanUpdater;
+
     public CheServerInfo getCheServerInfo(OpenShiftClient client, String namespace, String requestURL, String keycloakToken) {
         if (toggle.isMultiTenant(keycloakToken)) {
-            // multi-tenant che-server is supposed to be always accesible
-            return CheServerHelper.generateCheServerInfo(true, requestURL);
+            if (cheDeploymentConfig.deploymentExists(client, namespace)) {
+                // user is supposed to be multi-tenant but still has single-tenant che-server in the namespace,
+                // so tenant needs to be updated
+                tenanUpdater.update(keycloakToken);
+                // wait 10 seconds to make sure that che deployment would be deleted
+                try {
+                    TimeUnit.SECONDS.sleep(10);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+                return CheServerHelper.generateCheServerInfo(false, requestURL);
+            } else {
+                // multi-tenant che-server is supposed to be always accessible
+                return CheServerHelper.generateCheServerInfo(true, requestURL);
+            }
         }
 
         boolean isCheServerReadyToHandleRequests;

--- a/src/main/java/io/fabric8/che/starter/multi/tenant/TenantUpdater.java
+++ b/src/main/java/io/fabric8/che/starter/multi/tenant/TenantUpdater.java
@@ -1,0 +1,43 @@
+/*-
+ * #%L
+ * che-starter
+ * %%
+ * Copyright (C) 2017 Red Hat, Inc.
+ * %%
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * #L%
+ */
+package io.fabric8.che.starter.multi.tenant;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import io.fabric8.che.starter.client.keycloak.KeycloakRestTemplate;
+
+@Component
+public class TenantUpdater {
+    private static final Logger LOG = LoggerFactory.getLogger(TenantUpdater.class);
+
+    @Value("${UPDATE_TENANT_ENDPOINT:https://api.openshift.io/api/user/services}")
+    private String updateTenantEndpoint;
+
+    @Async
+    public void update(final String keycloakToken) {
+        RestTemplate template = new KeycloakRestTemplate(keycloakToken);
+        HttpComponentsClientHttpRequestFactory requestFactory = new HttpComponentsClientHttpRequestFactory();
+        template.setRequestFactory(requestFactory);
+        ResponseEntity<String> response = template.exchange(updateTenantEndpoint, HttpMethod.PATCH, null, String.class);
+        LOG.info("User tenant has been updated. Status code {}", response.getStatusCode());
+    }
+
+}

--- a/src/main/java/io/fabric8/che/starter/openshift/CheDeploymentConfig.java
+++ b/src/main/java/io/fabric8/che/starter/openshift/CheDeploymentConfig.java
@@ -53,6 +53,11 @@ public final class CheDeploymentConfig {
         }
     }
 
+    public boolean deploymentExists(OpenShiftClient client, String namespace) {
+        DeploymentConfig dc = getDeploymentConfig(client, namespace).get();
+        return (dc != null);
+    }
+
     public boolean isDeploymentAvailable(OpenShiftClient client, String namespace) {
         DeploymentConfig deploymentConfig = getDeploymentConfig(client, namespace).get();
         if (deploymentConfig == null) {

--- a/src/test/java/io/fabric8/che/starter/multi/tenant/TenantUpdaterTest.java
+++ b/src/test/java/io/fabric8/che/starter/multi/tenant/TenantUpdaterTest.java
@@ -1,0 +1,34 @@
+/*-
+ * #%L
+ * che-starter
+ * %%
+ * Copyright (C) 2017 Red Hat, Inc.
+ * %%
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * #L%
+ */
+
+package io.fabric8.che.starter.multi.tenant;
+
+import org.junit.Ignore;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import io.fabric8.che.starter.TestConfig;
+
+@Ignore("Valid keycloak token must be provided")
+public class TenantUpdaterTest extends TestConfig {
+    private static final String KEYCLOAK_TOKEN = "Bearer <KEYCLOAK TOKEN>";
+
+    @Autowired
+    private TenantUpdater tenanUpdater;
+
+    @Test
+    public void updateTenantTest() {
+        tenanUpdater.update(KEYCLOAK_TOKEN);
+    }
+
+}


### PR DESCRIPTION
Che starter needs to update tenant if user provisioned with multi-tenant che-server, but still has single-tenant che deployment in namespace
