### PR TITLE
che-starter #246: Adding API for making it possible to track multi-tenant migration status from UI / wit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,7 @@
         <logstash.logback.encoder.version>4.9</logstash.logback.encoder.version>
         <jjwt.version>0.7.0</jjwt.version>
         <unleash.client.java.version>2.1.4</unleash.client.java.version>
+        <org.apache.httpcomponents.version>4.5.3</org.apache.httpcomponents.version>
     </properties>
 
     <dependencies>
@@ -143,6 +144,12 @@
             <artifactId>unleash-client-java</artifactId>
             <version>${unleash.client.java.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+           <version>${org.apache.httpcomponents.version}</version>
+       </dependency>
 
     </dependencies>
 

--- a/src/main/java/io/fabric8/che/starter/client/CheServerClient.java
+++ b/src/main/java/io/fabric8/che/starter/client/CheServerClient.java
@@ -98,7 +98,8 @@ public class CheServerClient {
             }
             // migration has just started
             return CheServerHelper.generateCheServerInfo(false, requestURL, true);
-        } else if (migrationPod.isRunning(client, namespace)) {
+        } else if (migrationPod.exists(client, namespace)
+                && (!migrationPod.isReady(client, namespace) || migrationPod.isRunning(client, namespace))) {
             // migration is in progress
             return CheServerHelper.generateCheServerInfo(false, requestURL, true);
         } else if (migrationPod.isTerminated(client, namespace)) {

--- a/src/main/java/io/fabric8/che/starter/controller/CheServerController.java
+++ b/src/main/java/io/fabric8/che/starter/controller/CheServerController.java
@@ -26,6 +26,7 @@ import org.springframework.web.bind.annotation.RestController;
 import io.fabric8.che.starter.client.CheServerClient;
 import io.fabric8.che.starter.client.keycloak.KeycloakClient;
 import io.fabric8.che.starter.client.keycloak.KeycloakTokenValidator;
+import io.fabric8.che.starter.exception.MultiTenantMigrationException;
 import io.fabric8.che.starter.exception.RouteNotFoundException;
 import io.fabric8.che.starter.model.server.CheServerInfo;
 import io.fabric8.che.starter.openshift.OpenShiftClientWrapper;
@@ -89,7 +90,7 @@ public class CheServerController {
     }
 
     private CheServerInfo startServer(String masterUrl, String openShiftToken, String keycloakToken, String namespace, HttpServletResponse response,
-            HttpServletRequest request) throws RouteNotFoundException {
+            HttpServletRequest request) throws RouteNotFoundException, MultiTenantMigrationException {
         OpenShiftClient openShiftClient = openShiftClientWrapper.get(masterUrl, openShiftToken);
         String requestURL = request.getRequestURL().toString();
 

--- a/src/main/java/io/fabric8/che/starter/exception/GlobalExceptionHandler.java
+++ b/src/main/java/io/fabric8/che/starter/exception/GlobalExceptionHandler.java
@@ -92,4 +92,10 @@ public class GlobalExceptionHandler {
     public String handleWorkspaceNotFoundException(WorkspaceNotFound e) {
         return e.getMessage();
     }
+
+    @ResponseStatus(value = HttpStatus.INTERNAL_SERVER_ERROR, reason = "Migration to multi-tenant Che server has failed")
+    @ExceptionHandler(MultiTenantMigrationException.class)
+    public String handleMultiTenantMigrationException(WorkspaceNotFound e) {
+        return e.getMessage();
+    }
 }

--- a/src/main/java/io/fabric8/che/starter/exception/MultiTenantMigrationException.java
+++ b/src/main/java/io/fabric8/che/starter/exception/MultiTenantMigrationException.java
@@ -1,0 +1,32 @@
+/*-
+ * #%L
+ * che-starter
+ * %%
+ * Copyright (C) 2017 Red Hat, Inc.
+ * %%
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * #L%
+ */
+package io.fabric8.che.starter.exception;
+
+public class MultiTenantMigrationException extends Exception {
+    private static final long serialVersionUID = 1L;
+
+    public MultiTenantMigrationException() {
+    }
+
+    public MultiTenantMigrationException(String message) {
+        super(message);
+    }
+
+    public MultiTenantMigrationException(Throwable cause) {
+        super(cause);
+    }
+
+    public MultiTenantMigrationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/io/fabric8/che/starter/model/server/CheServerInfo.java
+++ b/src/main/java/io/fabric8/che/starter/model/server/CheServerInfo.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 public class CheServerInfo {
     private boolean isRunning;
     private List<CheServerLink> links;
+    private boolean isMultiTenant;
 
     public boolean isRunning() {
         return isRunning;
@@ -35,6 +36,14 @@ public class CheServerInfo {
 
     public void setLinks(List<CheServerLink> links) {
         this.links = links;
+    }
+
+    public boolean isMultiTenant() {
+        return isMultiTenant;
+    }
+
+    public void setMultiTenant(boolean isMultiTenant) {
+        this.isMultiTenant = isMultiTenant;
     }
 
 }

--- a/src/main/java/io/fabric8/che/starter/multi/tenant/MigrationCongigMap.java
+++ b/src/main/java/io/fabric8/che/starter/multi/tenant/MigrationCongigMap.java
@@ -1,0 +1,41 @@
+/*-
+ * #%L
+ * che-starter
+ * %%
+ * Copyright (C) 2017 Red Hat, Inc.
+ * %%
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * #L%
+ */
+package io.fabric8.che.starter.multi.tenant;
+
+import org.springframework.stereotype.Component;
+
+import io.fabric8.che.starter.exception.MultiTenantMigrationException;
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.openshift.client.OpenShiftClient;
+
+@Component
+public class MigrationCongigMap {
+    private static final String REQUEST_ID = "request-id";
+    private static final String MIGRATION_CONFIG_MAP_NAME = "migration";
+
+    public boolean exists(final OpenShiftClient client, final String namespace) {
+        return getConfigMap(client, namespace) != null;
+    }
+
+    public String getRequestId(final OpenShiftClient client, final String namespace) throws MultiTenantMigrationException {
+        ConfigMap cm = getConfigMap(client, namespace);
+        if (cm == null) {
+            throw new MultiTenantMigrationException(MIGRATION_CONFIG_MAP_NAME + " config map does not exist");
+        }
+        return cm.getData().get(REQUEST_ID);
+    }
+
+    private ConfigMap getConfigMap(final OpenShiftClient client, final String namespace) {
+        return client.configMaps().inNamespace(namespace).withName(MIGRATION_CONFIG_MAP_NAME).get();
+    }
+}

--- a/src/main/java/io/fabric8/che/starter/multi/tenant/MigrationPod.java
+++ b/src/main/java/io/fabric8/che/starter/multi/tenant/MigrationPod.java
@@ -33,6 +33,19 @@ public class MigrationPod {
     @Autowired
     MigrationCongigMap migrationCongigMap;
 
+    public boolean exists(final OpenShiftClient client, final String namespace) {
+        Pod pod = getPod(client, namespace);
+        return (pod != null);
+    }
+
+    public boolean isReady(final OpenShiftClient client, final String namespace) {
+        Pod pod = getPod(client, namespace);
+        if (pod != null) {
+            return pod.getStatus().getContainerStatuses().get(0).getReady();
+        }
+        return false;
+    }
+
     public boolean isRunning(final OpenShiftClient client, final String namespace) {
         Pod pod = getPod(client, namespace);
         if (pod != null) {

--- a/src/main/java/io/fabric8/che/starter/multi/tenant/MigrationPod.java
+++ b/src/main/java/io/fabric8/che/starter/multi/tenant/MigrationPod.java
@@ -1,0 +1,73 @@
+/*-
+ * #%L
+ * che-starter
+ * %%
+ * Copyright (C) 2017 Red Hat, Inc.
+ * %%
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * #L%
+ */
+package io.fabric8.che.starter.multi.tenant;
+
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import io.fabric8.kubernetes.api.model.ContainerStateRunning;
+import io.fabric8.kubernetes.api.model.ContainerStateTerminated;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.openshift.client.OpenShiftClient;
+
+@Component
+public class MigrationPod {
+    private static final Logger LOG = LoggerFactory.getLogger(MigrationPod.class);
+    private static final String MIGRATION_POD_LABEL = "migration";
+    private static final String REQUEST_ID_ANNOTATION = "request-id";
+
+    @Autowired
+    MigrationCongigMap migrationCongigMap;
+
+    public boolean isRunning(final OpenShiftClient client, final String namespace) {
+        Pod pod = getPod(client, namespace);
+        if (pod != null) {
+            ContainerStateRunning running = pod.getStatus().getContainerStatuses().get(0).getState().getRunning();
+            return (running != null);
+        }
+        return false;
+    }
+
+    public boolean isTerminated(final OpenShiftClient client, final String namespace) {
+        Pod pod = getPod(client, namespace);
+        if (pod != null) {
+            ContainerStateTerminated terminated = pod.getStatus().getContainerStatuses().get(0).getState().getTerminated();
+            return (terminated != null);
+        }
+        return false;
+    }
+
+    private Pod getPod(OpenShiftClient client, String namespace) {
+        try {
+            Pod migrationPod = null;
+            String requestId = migrationCongigMap.getRequestId(client, namespace);
+            List<Pod> pods = client.pods().inNamespace(namespace).withLabel(MIGRATION_POD_LABEL).list().getItems();
+            for (Pod pod : pods) {
+                String requestIdAnnotaion = pod.getMetadata().getAnnotations().get(REQUEST_ID_ANNOTATION);
+                if (requestId.equals(requestIdAnnotaion)) {
+                    migrationPod = pod;
+                    break;
+                }
+            }
+            return migrationPod;
+        } catch (Exception e) {
+            LOG.error("Error occured during migration to multi-tenant Che server", e);
+            return null;
+        }
+    }
+
+}

--- a/src/main/java/io/fabric8/che/starter/multi/tenant/TenantUpdater.java
+++ b/src/main/java/io/fabric8/che/starter/multi/tenant/TenantUpdater.java
@@ -12,9 +12,14 @@
  */
 package io.fabric8.che.starter.multi.tenant;
 
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
@@ -27,6 +32,8 @@ import io.fabric8.che.starter.client.keycloak.KeycloakRestTemplate;
 @Component
 public class TenantUpdater {
     private static final Logger LOG = LoggerFactory.getLogger(TenantUpdater.class);
+    private static final String REQUEST_ID_HEADER = "X-Request-Id";
+    private static final String REQUEST_ID_MDC_KEY = "req_id";
 
     @Value("${UPDATE_TENANT_ENDPOINT:https://api.openshift.io/api/user/services}")
     private String updateTenantEndpoint;
@@ -34,10 +41,20 @@ public class TenantUpdater {
     @Async
     public void update(final String keycloakToken) {
         RestTemplate template = new KeycloakRestTemplate(keycloakToken);
+        HttpHeaders headers = new HttpHeaders();
+        headers.set(REQUEST_ID_HEADER, getRequestId());
+        HttpEntity<String> entity = new HttpEntity<String>("parameters", headers);
+
         HttpComponentsClientHttpRequestFactory requestFactory = new HttpComponentsClientHttpRequestFactory();
         template.setRequestFactory(requestFactory);
-        ResponseEntity<String> response = template.exchange(updateTenantEndpoint, HttpMethod.PATCH, null, String.class);
+        ResponseEntity<String> response = template.exchange(updateTenantEndpoint, HttpMethod.PATCH, entity, String.class);
         LOG.info("User tenant has been updated. Status code {}", response.getStatusCode());
     }
+
+    private String getRequestId() {
+        String requestId = MDC.get(REQUEST_ID_MDC_KEY);
+        return StringUtils.isNotBlank (requestId) ? requestId : RandomStringUtils.random(16, true, true).toLowerCase();
+    }
+
 
 }

--- a/src/main/java/io/fabric8/che/starter/util/CheServerHelper.java
+++ b/src/main/java/io/fabric8/che/starter/util/CheServerHelper.java
@@ -24,11 +24,12 @@ public final class CheServerHelper {
     private CheServerHelper() {
     }
 
-    public static CheServerInfo generateCheServerInfo(boolean isRunning, String requestURL) {
+    public static CheServerInfo generateCheServerInfo(boolean isRunning, String requestURL, boolean isMultiTenant) {
         CheServerInfo info = new CheServerInfo();
         info.setRunning(isRunning);
         CheServerLink statusLink = CheServerHelper.generateStatusLink(requestURL);
         info.setLinks(Collections.singletonList(statusLink));
+        info.setMultiTenant(isMultiTenant);
         return info;
     }
 

--- a/src/test/java/io/fabric8/che/starter/util/CheServerHelperTest.java
+++ b/src/test/java/io/fabric8/che/starter/util/CheServerHelperTest.java
@@ -12,9 +12,9 @@
  */
 package io.fabric8.che.starter.util;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 
@@ -26,15 +26,17 @@ import io.fabric8.che.starter.model.server.CheServerLink;
 
 public class CheServerHelperTest extends TestConfig {
     private static final boolean IS_RUNNING = true;
+    private static final boolean IS_MULTI_TENANT = false;
     private static final String REQUEST_URL = "http://localhost:10000/server";
 
     @Test
     public void checkCheServerStatusLink() {
-        CheServerInfo info = CheServerHelper.generateCheServerInfo(IS_RUNNING, REQUEST_URL);
+        CheServerInfo info = CheServerHelper.generateCheServerInfo(IS_RUNNING, REQUEST_URL, IS_MULTI_TENANT);
         List<CheServerLink> links = info.getLinks();
 
         assertTrue(info.isRunning());
         assertFalse(links.isEmpty());
+        assertFalse(info.isMultiTenant());
 
         CheServerLink statusLink = links.stream()
                 .filter(link -> CheServerHelper.CHE_SERVER_STATUS_URL.equals(link.getRel())).findFirst().get();


### PR DESCRIPTION
This PR is the first step of making it possible to track migration to multi-tenant che-server from Codebases UI. When the PR was created there were two major assumptions:

- getting migration status must be asyncronous in order to avoid issue like https://github.com/redhat-developer/che-starter/issues/145
- changes on UI / wit level should be minor

Here is the migration lifecycle:

-  che-starter calls `update teant`
- `migration` config map (with the OSIO token of the current user + request Id + identityId) is created
- `fabric-tenant-che-migration-xxxxxxx` POD that will start immediately and run exactly once
-  Migration POD will:

1. check that the migration should be done (single-tenant che-server still there)
2. start the che-server if it is idled
3. do the workspace migration
4. clean the single-tenant Openshift resource, finishing by the che config map, **but only if workspace migration succeeded**
5. delete the migration config map in any case
6. will exit (since it's a command-line application) with either 0 or 1 exit code
7. which will make the POD terminated as either completed (exit code 0) or failed (exit code 1)

Taking major objections & migration lifecycle into account, the easiest way to add migration notifications to UI is to add `isMultiTenant` property to the `CheServerState` (`isRunning` property, that is used for tracking if single-tenant che-server is idled, for multi-tenant would be used as an indicator of migration state  `true` - migration is done / `false` - migration is in progress)

How all is going to work from che-starter perspective. Basically, there are 3 potential states[1]:

1. Single tenant che deployment is still in *-che namespace and `migration` cm does **not** exist  - che-starter calls update tenant and send in response that multi-tenant che-server is `not` yet ready (migration has started)
2. Migration POD exists - migration is in progress
3. Single tenant che deployment does not exist as well as migration POD - migration has finished

NOTE: in the current implementation che-starter does not notify UI / wit if the error occurs during migration, because it either will be blocking operation, or not trivial to implement (require reworking of ui / wit / che-starter to support long-polling). In general, if migration is failed for some user it was decided that email notifications would be send to che team since it is considered to be an outstanding situation. So, if error occurs during the migration che-starter will just retry to do it on another request from UI, assuming that single-tenant resource cleanup happens only if workspace migration succeeded (so, `che` deployment would still be there once migration failed). Also, if migration will not be finished in 3 mins timeout occurs and UI shows smth. like `Migration to multi-tenant che-server has failed`

[1] https://github.com/redhat-developer/che-starter/pull/247/files#diff-cf8fe0a91f69533a082c93186c0b65e5R87






 