### PR TITLE
Adding 'che.server.url' pointing to che 6 in openshift template

### DIFF
--- a/openshift-template/che-starter.app.yaml
+++ b/openshift-template/che-starter.app.yaml
@@ -75,6 +75,11 @@ objects:
                 configMapKeyRef:
                   name: che-starter
                   key: multi.tenant.che.server.url
+            - name: CHE_SERVER_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: che-starter
+                  key: che.server.url
             - name: UPDATE_TENANT_ENDPOINT
               valueFrom:
                 configMapKeyRef:

--- a/openshift-template/che-starter.config.yaml
+++ b/openshift-template/che-starter.config.yaml
@@ -11,3 +11,4 @@ data:
   github.tokenurl: https://auth.prod-preview.openshift.io/api/token?for=https://github.com
   multi.tenant.che.server.url: https://che.prod-preview.openshift.io
   update.tenant.endpoint: https://api.prod-preview.openshift.io/api/user/services
+  che.server.url: https://che.prod-preview.openshift.io


### PR DESCRIPTION
Signed-off-by: Ilya Buziuk <ibuziuk@redhat.com>