### PR TITLE
Move to Quay.io

### DIFF
--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,4 +1,4 @@
-FROM prod.registry.devshift.net/osio-prod/base/jboss-jdk-8:latest
+FROM quay.io/openshiftio/rhel-base-jboss-jdk-8:latest
 
 ARG VERSION=1.0-SNAPSHOT
 

--- a/cico_run_tests.sh
+++ b/cico_run_tests.sh
@@ -12,19 +12,15 @@
 # http://www.eclipse.org/legal/epl-v10.html
 # #L%
 ###
-cat jenkins-env | grep -e KEYCLOAK_TOKEN > inherit-env
-. inherit-env
+
+eval "$(./env-toolkit load -f jenkins-env.json KEYCLOAK_TOKEN)"
 
 yum -y update
-yum -y install centos-release-scl java-1.8.0-openjdk-devel curl
+yum -y install epel-release
+yum -y install centos-release-scl java-1.8.0-openjdk-devel curl jq
 yum -y install rh-maven33
 
-# installing jq via curl since 'No package jq available' for yum
-curl -LO https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64
-mv jq-linux64 /usr/bin/jq
-chmod +x /usr/bin/jq
-
-# Keycloak token provided by `che_functional_tests_credentials_wrapper` from `openshiftio-cico-jobs` is a refresh token. 
+# Keycloak token provided by `che_functional_tests_credentials_wrapper` from `openshiftio-cico-jobs` is a refresh token.
 # Obtaining osio user token
 AUTH_RESPONSE=$(curl -H "Content-Type: application/json" -X POST -d '{"refresh_token":"'$KEYCLOAK_TOKEN'"}' https://auth.prod-preview.openshift.io/api/token/refresh)
 


### PR DESCRIPTION
This PR is part of the effort to move to Quay.

This is the list of changes in this PR:

- Pushes to Quay instead of the Devshift registry
- Uses an image hosted in Quay to build the RHEL based container image
- Uses the new env-toolkit to load variables from jenkins-env
- Changes the default path of the image to quay (note that this should not affect production because it is overridden in the saas repo)

A companion PR should have been submitted to the appropriate saas repo to change the staging url from devshift to quay. The PR to the saas repo should be merged before this one.
https://github.com/openshiftio/saas-openshiftio/pull/951