### PR TITLE
Fix squid s1488 s1858

### DIFF
--- a/src/main/java/io/fabric8/che/starter/client/github/GitHubTokenProvider.java
+++ b/src/main/java/io/fabric8/che/starter/client/github/GitHubTokenProvider.java
@@ -56,7 +56,7 @@ public class GitHubTokenProvider {
 
     private String getResponseBody(String endpoint, String keycloakToken) {
         RestTemplate template = new KeycloakRestTemplate(keycloakToken);
-        ResponseEntity<String> response = template.exchange(endpoint.toString(), HttpMethod.GET, null, String.class);
+        ResponseEntity<String> response = template.exchange(endpoint, HttpMethod.GET, null, String.class);
         return response.getBody();
     }
 

--- a/src/main/java/io/fabric8/che/starter/client/github/GitHubTokenProvider.java
+++ b/src/main/java/io/fabric8/che/starter/client/github/GitHubTokenProvider.java
@@ -40,8 +40,7 @@ public class GitHubTokenProvider {
     public String getGitHubToken(String keycloakToken) throws KeycloakException, JsonProcessingException, IOException {
         LOG.info("GitHub token url - {}", gitHubTokenUrl);
         // {"access_token":"token","scope":"admin:repo_hook,gist,read:org,repo,user","token_type":"bearer"}
-        String token = getAccessToken(gitHubTokenUrl, keycloakToken);
-        return token;
+        return getAccessToken(gitHubTokenUrl, keycloakToken);
     }
 
     private String getAccessToken(String endpoint, String keycloakToken) throws KeycloakException, JsonProcessingException, IOException {


### PR DESCRIPTION
fixing squid:S1488 & squid:S1858
https://next.sonarqube.com/sonarqube/coding_rules?open=squid%3AS1488&q=S1488
https://next.sonarqube.com/sonarqube/coding_rules?open=squid%3AS1858&q=S1858

Removing local variable token and returning immediately. 

Removing .toString() call on endpoint since it is already a string.